### PR TITLE
Focus visible test

### DIFF
--- a/.github/actions/link-package/action.yml
+++ b/.github/actions/link-package/action.yml
@@ -50,7 +50,7 @@ runs:
 
     - name: Link JupyterLab and external package 🔗
       run: |
-        conda run --prefix $CONDA_PREFIX yarn link "${{ github.workspace }}/external-pkg" -p
+        conda run --prefix $CONDA_PREFIX jlpm link "${{ github.workspace }}/external-pkg" --private --all
         conda run --prefix $CONDA_PREFIX jlpm run build
       shell: bash -l {0}
       working-directory: jupyterlab

--- a/.github/actions/link-package/action.yml
+++ b/.github/actions/link-package/action.yml
@@ -49,6 +49,11 @@ runs:
       working-directory: external-pkg
 
     - name: Link JupyterLab and external package 🔗
+      # Note (--all): you must add the `--all` suffix to the yarn (jlpm) link
+      # command to link in all sub-packages of a monorepo. When this action was
+      # run without the --all option, a test failed that should have passed
+      # because some changes in a Lumino sub-package were not incorporated into
+      # the JupyterLab build.
       run: |
         conda run --prefix $CONDA_PREFIX jlpm link "${{ github.workspace }}/external-pkg" --private --all
         conda run --prefix $CONDA_PREFIX jlpm run build

--- a/testing/jupyterlab/manual-testing-scripts/visible-focus-indicator-initial-page.md
+++ b/testing/jupyterlab/manual-testing-scripts/visible-focus-indicator-initial-page.md
@@ -64,5 +64,5 @@ page](assets/no-tab-trap-initial-page/jupyterlab-initial-page.png)
 5. If at any point, you lost track of which element had focus, then the test
    fails. Another way to say this is that if at any point you pressed the
    <kbd>TAB</kbd> key and you could not find the element which had focus, then
-   it means that the focus indicator was not visuble (or maybe not visible
+   it means that the focus indicator was not visible (or maybe not visible
    enough).

--- a/testing/jupyterlab/manual-testing-scripts/visible-focus-indicator-initial-page.md
+++ b/testing/jupyterlab/manual-testing-scripts/visible-focus-indicator-initial-page.md
@@ -1,0 +1,68 @@
+# Visible Focus Indicator on Initial Page
+
+## Description
+
+When a user loads JupyterLab, if they use the tab key to navigate the page, each
+tab-focussable element on the page should have a visible indicator when it
+receives focus. 
+
+## Applicability
+
+Which apps does this test currently apply to?
+
+- JupyterLab
+
+## Related GitHub PRs
+
+These PRs were needed to make this test pass:
+
+[Make focus visible (mostly CSS)
+#13415](https://github.com/jupyterlab/jupyterlab/pull/13415)
+
+## Related GitHub Issues
+
+[JupyterLab #9399](https://github.com/jupyterlab/jupyterlab/pull/9399) - in the
+PR description, look under "Focus", Issue Area #2. 
+
+## Related Accessibility Guidelines
+
+[Understanding WCAG 2.4.7: Focus
+Visible](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html)
+
+## How to Interpret Test Results
+
+The test only checks for the existence of a focus indicator on each tab-focussed
+element. It does not check whether or not the focus indicator is a **good**
+focus indicator. For example, the test does not check the color contrast of the
+focus indicator. 
+
+The test checks for a focus indicator by taking screenshots of each
+tab-focussable element both before and after the element is focussed, then
+comparing the screenshots. A single pixel difference will cause the test to
+pass. This is why the test cannot tell you if the focus indicator is good; it
+can only tell you if the visual area around the element changes when it has
+focus versus when it does not.
+
+So a test failure means that the app under test fails the WCAG 2.4.7 success
+criteria (assuming no bugs in the test itself), but a test success does not mean
+that the app fulfills the spirit of the guideline, which is to make it easy for
+all sighted users to know which element on the page has browser focus.
+
+## How to Perform the Test Manually
+
+1. Open JupyterLab in a fresh environment. Another way to say this is that you
+   should have the following parts visible: top menu bar, left side panel with
+   file browser open, the launcher in the main area, right side panel closed,
+   and status bar. Here's a screenshot: ![screenshot of JupyterLab initial
+   page](assets/no-tab-trap-initial-page/jupyterlab-initial-page.png)
+2. Press the <kbd>TAB</kbd> key repeatedly.
+3. Each time you press the <kbd>TAB</kbd> key, you should be able to clearly see
+   which element (whether it is a link, a button, or some other element), has
+   focus. 
+4. Continue pressing the <kbd>TAB</kbd> key and checking for focus indicator
+   until you cycle back around. 
+5. If at any point, you lost track of which element had focus, then the test
+   fails. Another way to say this is that if at any point you pressed the
+   <kbd>TAB</kbd> key and you could not find the element which had focus, then
+   it means that the focus indicator was not visuble (or maybe not visible
+   enough).

--- a/testing/jupyterlab/manual-testing-scripts/visible-focus-indicator-initial-page.md
+++ b/testing/jupyterlab/manual-testing-scripts/visible-focus-indicator-initial-page.md
@@ -4,7 +4,7 @@
 
 When a user loads JupyterLab, if they use the tab key to navigate the page, each
 tab-focussable element on the page should have a visible indicator when it
-receives focus. 
+receives focus.
 
 ## Applicability
 
@@ -22,7 +22,7 @@ These PRs were needed to make this test pass:
 ## Related GitHub Issues
 
 [JupyterLab #9399](https://github.com/jupyterlab/jupyterlab/pull/9399) - in the
-PR description, look under "Focus", Issue Area #2. 
+PR description, look under "Focus", Issue Area #2.
 
 ## Related Accessibility Guidelines
 
@@ -34,7 +34,7 @@ Visible](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html)
 The test only checks for the existence of a focus indicator on each tab-focussed
 element. It does not check whether or not the focus indicator is a **good**
 focus indicator. For example, the test does not check the color contrast of the
-focus indicator. 
+focus indicator.
 
 The test checks for a focus indicator by taking screenshots of each
 tab-focussable element both before and after the element is focussed, then
@@ -54,13 +54,13 @@ all sighted users to know which element on the page has browser focus.
    should have the following parts visible: top menu bar, left side panel with
    file browser open, the launcher in the main area, right side panel closed,
    and status bar. Here's a screenshot: ![screenshot of JupyterLab initial
-   page](assets/no-tab-trap-initial-page/jupyterlab-initial-page.png)
+page](assets/no-tab-trap-initial-page/jupyterlab-initial-page.png)
 2. Press the <kbd>TAB</kbd> key repeatedly.
 3. Each time you press the <kbd>TAB</kbd> key, you should be able to clearly see
    which element (whether it is a link, a button, or some other element), has
-   focus. 
+   focus.
 4. Continue pressing the <kbd>TAB</kbd> key and checking for focus indicator
-   until you cycle back around. 
+   until you cycle back around.
 5. If at any point, you lost track of which element had focus, then the test
    fails. Another way to say this is that if at any point you pressed the
    <kbd>TAB</kbd> key and you could not find the element which had focus, then

--- a/testing/jupyterlab/tests/regression-tests/visible-focus-indicator-initial-page.test.ts
+++ b/testing/jupyterlab/tests/regression-tests/visible-focus-indicator-initial-page.test.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Jupyter Accessibility Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import { ElementHandle, expect } from "@playwright/test";
+import { test } from "@jupyterlab/galata";
+
+test("should have visible focus indicator", async (
+  { page }, testInfo
+) => {
+
+  await page.keyboard.press("Tab");
+  let start = await page.evaluateHandle(() =>  document.activeElement) as ElementHandle;
+  let node = start;
+
+  while (true) {
+    const focus = await node.screenshot();
+    await page.keyboard.press("Tab");
+    const noFocus = await node.screenshot();
+
+    await testInfo.attach("focussed", {
+      body: focus,
+      contentType: "image/png",
+    });
+    await testInfo.attach("unfocussed", {
+      body: noFocus,
+      contentType: "image/png",
+    });
+
+    expect(
+      focus.equals(noFocus)
+    ).toBe(false);
+
+    node = await page.evaluateHandle(() => document.activeElement) as ElementHandle;
+    if (await page.evaluate(([current, start]) => current === start, [node, start])) {
+      break;
+    }
+  }
+});

--- a/testing/jupyterlab/tests/regression-tests/visible-focus-indicator-initial-page.test.ts
+++ b/testing/jupyterlab/tests/regression-tests/visible-focus-indicator-initial-page.test.ts
@@ -5,21 +5,28 @@ import { ElementHandle, expect } from "@playwright/test";
 import { test } from "@jupyterlab/galata";
 
 async function* getNodesInFocusOrder(page) {
-  let start = await page.evaluateHandle(() =>  document.activeElement) as ElementHandle;
+  let start = (await page.evaluateHandle(
+    () => document.activeElement,
+  )) as ElementHandle;
   let node = start;
   while (true) {
     yield node;
     await page.keyboard.press("Tab");
-    node = await page.evaluateHandle(() => document.activeElement) as ElementHandle;
-    if (await page.evaluate(([current, start]) => current === start, [node, start])) {
+    node = (await page.evaluateHandle(
+      () => document.activeElement,
+    )) as ElementHandle;
+    if (
+      await page.evaluate(
+        ([current, start]) => current === start,
+        [node, start],
+      )
+    ) {
       break;
     }
   }
 }
 
-test("should have visible focus indicator", async (
-  { page }, testInfo
-) => {
+test("should have visible focus indicator", async ({ page }, testInfo) => {
   for await (const node of getNodesInFocusOrder(page)) {
     const box = await node.boundingBox();
     if (box === null) {
@@ -31,7 +38,7 @@ test("should have visible focus indicator", async (
       x: x - pad,
       y: y - pad,
       width: pad + width + pad,
-      height: pad + height + pad
+      height: pad + height + pad,
     };
 
     const focus = await page.screenshot({ clip });
@@ -49,8 +56,6 @@ test("should have visible focus indicator", async (
       contentType: "image/png",
     });
 
-    expect(
-      focus.equals(noFocus)
-    ).toBe(false);
+    expect(focus.equals(noFocus)).toBe(false);
   }
 });

--- a/testing/jupyterlab/tests/regression-tests/visible-focus-indicator-initial-page.test.ts
+++ b/testing/jupyterlab/tests/regression-tests/visible-focus-indicator-initial-page.test.ts
@@ -4,18 +4,41 @@
 import { ElementHandle, expect } from "@playwright/test";
 import { test } from "@jupyterlab/galata";
 
+async function* getNodesInFocusOrder(page) {
+  let start = await page.evaluateHandle(() =>  document.activeElement) as ElementHandle;
+  let node = start;
+  while (true) {
+    yield node;
+    await page.keyboard.press("Tab");
+    node = await page.evaluateHandle(() => document.activeElement) as ElementHandle;
+    if (await page.evaluate(([current, start]) => current === start, [node, start])) {
+      break;
+    }
+  }
+}
+
 test("should have visible focus indicator", async (
   { page }, testInfo
 ) => {
+  for await (const node of getNodesInFocusOrder(page)) {
+    const box = await node.boundingBox();
+    if (box === null) {
+      throw new Error("Could not get node bounding box");
+    }
+    const { x, y, width, height } = box;
+    const pad = 3; // this value is just from trial-and-error
+    const clip = {
+      x: x - pad,
+      y: y - pad,
+      width: pad + width + pad,
+      height: pad + height + pad
+    };
 
-  await page.keyboard.press("Tab");
-  let start = await page.evaluateHandle(() =>  document.activeElement) as ElementHandle;
-  let node = start;
+    const focus = await page.screenshot({ clip });
+    await node.evaluate((node) => (node as HTMLElement).blur());
 
-  while (true) {
-    const focus = await node.screenshot();
-    await page.keyboard.press("Tab");
-    const noFocus = await node.screenshot();
+    const noFocus = await page.screenshot({ clip });
+    await node.evaluate((node) => (node as HTMLElement).focus());
 
     await testInfo.attach("focussed", {
       body: focus,
@@ -29,10 +52,5 @@ test("should have visible focus indicator", async (
     expect(
       focus.equals(noFocus)
     ).toBe(false);
-
-    node = await page.evaluateHandle(() => document.activeElement) as ElementHandle;
-    if (await page.evaluate(([current, start]) => current === start, [node, start])) {
-      break;
-    }
   }
 });

--- a/testing/jupyterlab/tests/regression-tests/visible-focus-indicator-initial-page.test.ts
+++ b/testing/jupyterlab/tests/regression-tests/visible-focus-indicator-initial-page.test.ts
@@ -49,7 +49,12 @@ async function* getFocusNodes(page: Page) {
     const nextNode = await nextFocusNode(page);
 
     // Break out of the loop if we have cycled back to the start.
-    if (await page.evaluate(([nextNode, start]) => nextNode === start, [nextNode, start])) {
+    if (
+      await page.evaluate(
+        ([nextNode, start]) => nextNode === start,
+        [nextNode, start],
+      )
+    ) {
       break;
     } else {
       // Otherwise do another turn of the loop.

--- a/testing/jupyterlab/tests/regression-tests/visible-focus-indicator-initial-page.test.ts
+++ b/testing/jupyterlab/tests/regression-tests/visible-focus-indicator-initial-page.test.ts
@@ -114,13 +114,15 @@ test("should have visible focus indicator", async ({ page }, testInfo) => {
     // expect.soft so that the test will iterate through all of the
     // tab-focussable nodes on the page instead of bailing on the first node
     // that fails the test.
-    expect.soft(
-      // Buffer.equals uses bit-for-bit equality, equivalent to comparing both
-      // screenshots pixel for pixel. If the screenshots are exactly the same,
-      // we know for sure that there was no visible focus indicator, so the test
-      // fails.
-      focus.equals(noFocus),
-      `focus visible comparison failed on\n\t${node.toString()}`
-    ).toBe(false);
+    expect
+      .soft(
+        // Buffer.equals uses bit-for-bit equality, equivalent to comparing both
+        // screenshots pixel for pixel. If the screenshots are exactly the same,
+        // we know for sure that there was no visible focus indicator, so the test
+        // fails.
+        focus.equals(noFocus),
+        `focus visible comparison failed on\n\t${node.toString()}`,
+      )
+      .toBe(false);
   }
 });

--- a/testing/jupyterlab/tests/regression-tests/visible-focus-indicator-initial-page.test.ts
+++ b/testing/jupyterlab/tests/regression-tests/visible-focus-indicator-initial-page.test.ts
@@ -110,13 +110,17 @@ test("should have visible focus indicator", async ({ page }, testInfo) => {
       contentType: "image/png",
     });
 
-    // Compare the screenshots. If they are equal, the test fails.
-    try {
-      expect(focus.equals(noFocus)).toBe(false);
-    } catch (err) {
-      console.log("Test failed at the following node:");
-      console.log(node.toString());
-      throw err;
-    }
+    // Compare the screenshots. If they are equal, the test fails. Use
+    // expect.soft so that the test will iterate through all of the
+    // tab-focussable nodes on the page instead of bailing on the first node
+    // that fails the test.
+    expect.soft(
+      // Buffer.equals uses bit-for-bit equality, equivalent to comparing both
+      // screenshots pixel for pixel. If the screenshots are exactly the same,
+      // we know for sure that there was no visible focus indicator, so the test
+      // fails.
+      focus.equals(noFocus),
+      `focus visible comparison failed on\n\t${node.toString()}`
+    ).toBe(false);
   }
 });

--- a/testing/jupyterlab/tests/regression-tests/visible-focus-indicator-initial-page.test.ts
+++ b/testing/jupyterlab/tests/regression-tests/visible-focus-indicator-initial-page.test.ts
@@ -20,8 +20,8 @@ async function nextFocusNode(page: Page) {
 }
 
 /**
- * Generator function to iterate through the tab-focussable nodes on the page
- * in tab-focus order.
+ * Generator function to iterate through the tab-focussable nodes on the page in
+ * tab-focus order.
  *
  * Note: when the function yields a node, that node currently has the browser
  * focus.
@@ -122,10 +122,10 @@ test.describe("every tab-focusable element on initial app page", () => {
       // that fails the test.
       expect
         .soft(
-          // Buffer.equals uses bit-for-bit equality, equivalent to comparing both
-          // screenshots pixel for pixel. If the screenshots are exactly the same,
-          // we know for sure that there was no visible focus indicator, so the test
-          // fails.
+          // Buffer.equals uses bit-for-bit equality, equivalent to comparing
+          // both screenshots pixel for pixel. If the screenshots are exactly
+          // the same, we know for sure that there was no visible focus
+          // indicator, so the test fails.
           focus.equals(noFocus),
           `focus visible comparison failed on\n\t${node.toString()}`,
         )


### PR DESCRIPTION
This PR adds a test to check that every tab-focusable element on the initial JupyterLab page load has a visible focus indicator. A full description of the test is in the markdown file added by this PR.

The test currently fails because the [skip link is broken](https://github.com/jupyterlab/jupyterlab/pull/14597).

There is another failure related to the top menu bar that https://github.com/jupyterlab/lumino/pull/607 fixes. You can see that the Lumino PR fixes the failure by examining [the results of a workflow that I manually dispatched](https://github.com/Quansight-Labs/jupyter-a11y-testing/actions/runs/5736784448). I configured that workflow to run the test in this PR against a build of JupyterLab that pulled in the Lumino fix. In the workflow run results, you can see that the focus visible comparison only fails on the skip link and not on any other DOM node (specifically, not on any DOM node in the menu bar).